### PR TITLE
Missing TextOptionsModifier on installation steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ Installation
 This requires django SHOP to work (https://github.com/chrisglass/django-shop)
 
 * Add the app to your INSTALLED_APPS in your settings.py
-* Add `shop_simplevariations.cart_modifier.ProductOptionsModifier` to your
+* Add `shop_simplevariations.cart_modifier.ProductOptionsModifier` and 
+  'shop_simplevariations.cart_modifier.TextOptionsModifier' to your
   `SHOP_CART_MODIFIERS` setting.
 * Add `(r'^shop/cart/', include(simplevariations_urls)),` to your `urls.py`
   just before `(r'^shop/', include(shop_urls)),`

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ This requires django SHOP to work (https://github.com/chrisglass/django-shop)
 
 * Add the app to your INSTALLED_APPS in your settings.py
 * Add `shop_simplevariations.cart_modifier.ProductOptionsModifier` and 
-  'shop_simplevariations.cart_modifier.TextOptionsModifier' to your
+  `shop_simplevariations.cart_modifier.TextOptionsModifier` to your 
   `SHOP_CART_MODIFIERS` setting.
 * Add `(r'^shop/cart/', include(simplevariations_urls)),` to your `urls.py`
   just before `(r'^shop/', include(shop_urls)),`


### PR DESCRIPTION
Hi, I am using this great plugin and got lost in this tricky settings detail.
I have wasted hours looking for a 'bug' where my Text options wasn't working. So, I guess that adding this configuration to the install steps would help newcomers.

edit: Oh, god... My git config is blank in this computer. 0wn3r is my machine name. Probably default settings.
